### PR TITLE
Update NativeUtils so it actually runs under other JDK's & Linux

### DIFF
--- a/src/main/java/com/github/sarxos/v4l4j/NativeUtils.java
+++ b/src/main/java/com/github/sarxos/v4l4j/NativeUtils.java
@@ -1,127 +1,118 @@
 package com.github.sarxos.v4l4j;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-
+import java.io.*;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.ProviderNotFoundException;
+import java.nio.file.StandardCopyOption;
 
 /**
- * Simple library class for working with JNI (Java Native Interface)
+ * A simple library class which helps with loading dynamic libraries stored in the
+ * JAR archive. These libraries usually contain implementation of some methods in
+ * native code (using JNI - Java Native Interface).
  * 
- * @see http://frommyplayground.com/how-to-load-native-jni-library-from-jar
- * @author Adam Heirnich <adam@adamh.cz>, http://www.adamh.cz
+ * @see <a href="http://adamheinrich.com/blog/2012/how-to-load-native-jni-library-from-jar">http://adamheinrich.com/blog/2012/how-to-load-native-jni-library-from-jar</a>
+ * @see <a href="https://github.com/adamheinrich/native-utils">https://github.com/adamheinrich/native-utils</a>
+ *
  */
 public class NativeUtils {
+ 
+    /**
+     * The minimum length a prefix for a file has to have according to {@link File#createTempFile(String, String)}}.
+     */
+    private static final int MIN_PREFIX_LENGTH = 3;
+    public static final String NATIVE_FOLDER_PATH_PREFIX = "nativeutils";
 
-	/**
-	 * Private constructor - this class will never be instanced
-	 */
-	private NativeUtils() {
-	}
+    /**
+     * Temporary directory which will contain the DLLs.
+     */
+    private static File temporaryDir;
 
-	/**
-	 * Loads library from current JAR archive
-	 * 
-	 * The file from JAR is copied into system temporary directory and then
-	 * loaded. The temporary file is deleted after exiting. Method uses String
-	 * as filename because the pathname is "abstract", not system-dependent.
-	 * 
-	 * @param filename The filename inside JAR as absolute path (beginning with
-	 *            '/'), e.g. /package/File.ext
-	 * @throws IOException If temporary file creation or read/write operation
-	 *             fails
-	 * @throws IllegalArgumentException If source file (param path) does not
-	 *             exist
-	 * @throws IllegalArgumentException If the path is not absolute or if the
-	 *             filename is shorter than three characters (restriction of
-	 *             {@see File#createTempFile(java.lang.String,
-	 *             java.lang.String)}).
-	 */
-	public static void loadLibraryFromJar(String jarpath, String[] libs) throws IOException {
+    /**
+     * Private constructor - this class will never be instanced
+     */
+    private NativeUtils() {
+    }
 
-		File libspath = File.createTempFile("libs", "");
-		if (!libspath.delete()) {
-			throw new IOException("Cannot clean " + libspath);
-		}
-		if (!libspath.exists()) {
-			if (!libspath.mkdirs()) {
-				throw new IOException("Cannot create directory " + libspath);
-			}
-		}
+    /**
+     * Loads library from current JAR archive
+     * 
+     * The file from JAR is copied into system temporary directory and then loaded. The temporary file is deleted after
+     * exiting.
+     * Method uses String as filename because the pathname is "abstract", not system-dependent.
+     * 
+     * @param path The path of file inside JAR as absolute path (beginning with '/'), e.g. /package/File.ext
+     * @throws IOException If temporary file creation or read/write operation fails
+     * @throws IllegalArgumentException If source file (param path) does not exist
+     * @throws IllegalArgumentException If the path is not absolute or if the filename is shorter than three characters
+     * (restriction of {@link File#createTempFile(java.lang.String, java.lang.String)}).
+     * @throws FileNotFoundException If the file could not be found inside the JAR.
+     */
+    public static void loadLibraryFromJar(String path) throws IOException {
+ 
+        if (null == path || !path.startsWith("/")) {
+            throw new IllegalArgumentException("The path has to be absolute (start with '/').");
+        }
+ 
+        // Obtain filename from path
+        String[] parts = path.split("/");
+        String filename = (parts.length > 1) ? parts[parts.length - 1] : null;
+ 
+        // Check if the filename is okay
+        if (filename == null || filename.length() < MIN_PREFIX_LENGTH) {
+            throw new IllegalArgumentException("The filename has to be at least 3 characters long.");
+        }
+ 
+        // Prepare temporary file
+        if (temporaryDir == null) {
+            temporaryDir = createTempDirectory(NATIVE_FOLDER_PATH_PREFIX);
+            temporaryDir.deleteOnExit();
+        }
 
-		libspath.deleteOnExit();
+        File temp = new File(temporaryDir, filename);
 
-		try {
-			addLibraryPath(libspath.getAbsolutePath());
-		} catch (Exception e) {
-			throw new IOException(e);
-		}
+        try (InputStream is = NativeUtils.class.getResourceAsStream(path)) {
+            Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            temp.delete();
+            throw e;
+        } catch (NullPointerException e) {
+            temp.delete();
+            throw new FileNotFoundException("File " + path + " was not found inside JAR.");
+        }
 
-		for (String lib : libs) {
+        try {
+            System.load(temp.getAbsolutePath());
+        } finally {
+            if (isPosixCompliant()) {
+                // Assume POSIX compliant file system, can be deleted after loading
+                temp.delete();
+            } else {
+                // Assume non-POSIX, and don't delete until last file descriptor closed
+                temp.deleteOnExit();
+            }
+        }
+    }
 
-			String libfile = "lib" + lib + ".so";
-			String path = jarpath + "/" + libfile;
+    private static boolean isPosixCompliant() {
+        try {
+            return FileSystems.getDefault()
+                    .supportedFileAttributeViews()
+                    .contains("posix");
+        } catch (FileSystemNotFoundException
+                | ProviderNotFoundException
+                | SecurityException e) {
+            return false;
+        }
+    }
 
-			if (!path.startsWith("/")) {
-				throw new IllegalArgumentException("The path to be absolute (start with '/').");
-			}
-
-			File file = new File(libspath, libfile);
-			file.createNewFile();
-			file.deleteOnExit();
-
-			byte[] buffer = new byte[1024];
-			int readBytes;
-
-			InputStream is = NativeUtils.class.getResourceAsStream(path);
-			if (is == null) {
-				throw new FileNotFoundException("File " + path + " was not found inside JAR.");
-			}
-
-			OutputStream os = new FileOutputStream(file);
-			try {
-				while ((readBytes = is.read(buffer)) != -1) {
-					os.write(buffer, 0, readBytes);
-				}
-			} finally {
-				os.close();
-				is.close();
-			}
-		}
-
-		for (String lib : libs) {
-			System.loadLibrary(lib);
-		}
-	}
-
-	/**
-	 * Adds the specified path to the java library path
-	 * 
-	 * @param pathToAdd the path to add
-	 * @throws Exception
-	 */
-	public static void addLibraryPath(String pathToAdd) throws Exception {
-		Field usrPathsField = ClassLoader.class.getDeclaredField("usr_paths");
-		usrPathsField.setAccessible(true);
-
-		// get array of paths
-		final String[] paths = (String[]) usrPathsField.get(null);
-
-		// check if the path to add is already present
-		for (String path : paths) {
-			if (path.equals(pathToAdd)) {
-				return;
-			}
-		}
-
-		// add the new path
-		final String[] newPaths = Arrays.copyOf(paths, paths.length + 1);
-		newPaths[newPaths.length - 1] = pathToAdd;
-		usrPathsField.set(null, newPaths);
-	}
-}
+    private static File createTempDirectory(String prefix) throws IOException {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        File generatedDir = new File(tempDir, prefix + System.nanoTime());
+        
+        if (!generatedDir.mkdir())
+            throw new IOException("Failed to create temp directory " + generatedDir.getName());
+        
+        return generatedDir;
+    }


### PR DESCRIPTION
Severely outdated NativeUtils comes with issues when using under Librca JDK & Linux.  
# Error
```
java.io.IOException: java.lang.NoSuchFieldException: usr_paths
        at com.github.sarxos.v4l4j.NativeUtils.loadLibraryFromJar(NativeUtils.java:62)
        at com.github.sarxos.v4l4j.V4L4J.init(V4L4J.java:50)
        at com.github.sarxos.webcam.ds.v4l4j.V4l4jDriver.<clinit>(V4l4jDriver.java:33)
        at lv.yourfriend.tester.Main.main(Main.java:67)
Caused by: java.lang.NoSuchFieldException: usr_paths
        at java.base/java.lang.Class.getDeclaredField(Class.java:2610)
        at com.github.sarxos.v4l4j.NativeUtils.addLibraryPath(NativeUtils.java:109)
        at com.github.sarxos.v4l4j.NativeUtils.loadLibraryFromJar(NativeUtils.java:60)
        ... 3 more
```
is produced when running this vl4j fork.
# Additional Information
(java 17.0.1-librca) ```
openjdk 17.0.1 2021-10-19 LTS
OpenJDK Runtime Environment (build 17.0.1+12-LTS)
OpenJDK Server VM (build 17.0.1+12-LTS, mixed mode)
```
Running latest version of both camera-capture and V4l4jDriver.